### PR TITLE
fix: tracking CLI entry point y reporte quality gates obligatorio

### DIFF
--- a/skills/implement-us/phases/phase-0-validation.md
+++ b/skills/implement-us/phases/phase-0-validation.md
@@ -11,7 +11,7 @@
 Ejecutá este comando antes de cualquier otra acción en esta fase:
 
 ```bash
-python .claude/tracking/track.py start-phase 0 "Validación de Contexto"
+python .claude/tracking/track.py start-phase 0 "Validación de Contexto" --us {US_ID}
 ```
 
 ---

--- a/skills/implement-us/phases/phase-7-quality-gates.md
+++ b/skills/implement-us/phases/phase-7-quality-gates.md
@@ -482,6 +482,51 @@ Agregar a observaciones del reporte:
 
 ---
 
+## 🔴 Acción Requerida — Generar reporte de quality gates
+
+Antes de cerrar el tracking, generá el reporte JSON con los resultados de todas las métricas:
+
+**Ubicación:** `quality/reports/{US_ID}-quality.json`
+
+Creá el archivo con los valores reales obtenidos en los pasos anteriores:
+
+```json
+{
+  "us_id": "{US_ID}",
+  "fecha": "{FECHA_ISO}",
+  "componente": "{COMPONENT_PATH}",
+  "metricas": {
+    "pylint": 0.0,
+    "cc_promedio": 0.0,
+    "mi_promedio": 0.0,
+    "coverage": 0.0
+  },
+  "umbrales": {
+    "pylint_min": 8.0,
+    "cc_max": 10,
+    "mi_min": 20,
+    "coverage_min": 95.0
+  },
+  "estado": "APROBADO",
+  "observaciones": []
+}
+```
+
+> Reemplazá los valores `0.0` con los resultados reales de pylint, radon y pytest-cov.
+> Leé los umbrales correctos del perfil activo con:
+> ```bash
+> cat .claude/skills/implement-us/config.json | jq '.quality_gates'
+> ```
+> Cambiá `"estado"` a `"RECHAZADO"` si alguna métrica no alcanza el umbral. Documentá la causa en `"observaciones"`.
+
+Si el directorio no existe, crealo:
+
+```bash
+mkdir -p quality/reports
+```
+
+---
+
 ## ✅ Checklist de Salida
 
 Antes de avanzar a Fase 8, confirmá que:

--- a/tests/test_tracking.py
+++ b/tests/test_tracking.py
@@ -128,6 +128,50 @@ class TestTimeTrackerLifecycle:
 
 
 # ─────────────────────────────────────────────────────────────────────────────
+# Tests: TimeTracker — from_json
+# ─────────────────────────────────────────────────────────────────────────────
+
+class TestTimeTrackerFromJson:
+    def test_from_json_restores_metadata(self, tracker_with_phase):
+        path = tracker_with_phase.storage_path
+        restored = TimeTracker.from_json(path)
+        assert restored.us_id == tracker_with_phase.us_id
+        assert restored.us_title == tracker_with_phase.us_title
+        assert restored.us_points == tracker_with_phase.us_points
+        assert restored.producto == tracker_with_phase.producto
+
+    def test_from_json_restores_started_at(self, started_tracker):
+        path = started_tracker.storage_path
+        restored = TimeTracker.from_json(path)
+        assert restored.started_at is not None
+
+    def test_from_json_restores_phases(self, tracker_with_phase):
+        path = tracker_with_phase.storage_path
+        restored = TimeTracker.from_json(path)
+        assert len(restored.phases) == 1
+        assert restored.phases[0].phase_number == 0
+
+    def test_from_json_restores_current_phase(self, tracker_with_phase):
+        path = tracker_with_phase.storage_path
+        restored = TimeTracker.from_json(path)
+        assert restored.current_phase is not None
+        assert restored.current_phase.phase_number == 0
+
+    def test_from_json_can_continue_phase(self, tracker_with_phase):
+        """Tracker restaurado permite cerrar la fase activa."""
+        path = tracker_with_phase.storage_path
+        restored = TimeTracker.from_json(path)
+        restored.end_phase(0)
+        assert restored.phases[0].status == "completed"
+
+    def test_from_json_completed_tracking(self, started_tracker):
+        started_tracker.end_tracking()
+        path = started_tracker.storage_path
+        restored = TimeTracker.from_json(path)
+        assert restored.completed_at is not None
+
+
+# ─────────────────────────────────────────────────────────────────────────────
 # Tests: TimeTracker — Fases
 # ─────────────────────────────────────────────────────────────────────────────
 

--- a/tracking/time_tracker.py
+++ b/tracking/time_tracker.py
@@ -397,6 +397,81 @@ class TimeTracker:
             None
         )
 
+    @classmethod
+    def from_json(cls, file_path: Path) -> 'TimeTracker':
+        """Carga un TimeTracker desde un archivo JSON existente.
+
+        Args:
+            file_path: Path al archivo JSON de tracking
+
+        Returns:
+            Instancia de TimeTracker con el estado restaurado
+        """
+        with open(file_path, 'r', encoding='utf-8') as f:
+            data = json.load(f)
+
+        metadata = data["metadata"]
+        tracker = cls(
+            us_id=metadata["us_id"],
+            us_title=metadata["us_title"],
+            us_points=metadata["us_points"],
+            producto=metadata["producto"]
+        )
+        tracker.storage_path = file_path
+
+        def _parse_dt(value: Optional[str]) -> Optional[datetime]:
+            if not value:
+                return None
+            return datetime.fromisoformat(value.replace('Z', '+00:00'))
+
+        timeline = data["timeline"]
+        tracker.started_at = _parse_dt(timeline.get("started_at"))
+        tracker.completed_at = _parse_dt(timeline.get("completed_at"))
+
+        for phase_data in data.get("phases", []):
+            phase = Phase(
+                phase_number=phase_data["phase_number"],
+                phase_name=phase_data["phase_name"],
+                started_at=_parse_dt(phase_data.get("started_at")),
+                completed_at=_parse_dt(phase_data.get("completed_at")),
+                elapsed_seconds=phase_data.get("elapsed_seconds", 0),
+                status=phase_data.get("status", "pending"),
+                auto_approved=phase_data.get("auto_approved", True),
+                user_approval_time_seconds=phase_data.get("user_approval_time_seconds", 0),
+            )
+            for task_data in phase_data.get("tasks", []):
+                task = Task(
+                    task_id=task_data["task_id"],
+                    task_name=task_data["task_name"],
+                    task_type=task_data["task_type"],
+                    estimated_minutes=task_data["estimated_minutes"],
+                    started_at=_parse_dt(task_data.get("started_at")),
+                    completed_at=_parse_dt(task_data.get("completed_at")),
+                    elapsed_seconds=task_data.get("elapsed_seconds", 0),
+                    file_created=task_data.get("file_created"),
+                    status=task_data.get("status", "pending"),
+                )
+                phase.tasks.append(task)
+                if task.status == "in_progress":
+                    tracker.current_task = task
+            tracker.phases.append(phase)
+            if phase.status == "in_progress":
+                tracker.current_phase = phase
+
+        for pause_data in data.get("pauses", []):
+            pause = Pause(
+                pause_id=pause_data["pause_id"],
+                started_at=_parse_dt(pause_data["started_at"]),
+                resumed_at=_parse_dt(pause_data.get("resumed_at")),
+                duration_seconds=pause_data.get("duration_seconds", 0),
+                reason=pause_data.get("reason", ""),
+            )
+            tracker.pauses.append(pause)
+            if pause.is_active:
+                tracker.current_pause = pause
+
+        return tracker
+
     def _save(self) -> None:
         """Guarda estado actual a JSON."""
         data = self._to_dict()

--- a/tracking/track.py
+++ b/tracking/track.py
@@ -1,0 +1,178 @@
+#!/usr/bin/env python3
+"""
+CLI de tracking para el skill /implement-us.
+
+Uso:
+    python .claude/tracking/track.py start-phase <N> "<nombre>" --us <US_ID>
+    python .claude/tracking/track.py end-phase <N> [--us <US_ID>]
+    python .claude/tracking/track.py start-task "<nombre>" [--us <US_ID>]
+    python .claude/tracking/track.py end-task "<nombre>" [--us <US_ID>]
+    python .claude/tracking/track.py end-tracking [--us <US_ID>]
+"""
+import argparse
+import json
+import sys
+from pathlib import Path
+
+# Asegurar que el directorio raíz del proyecto esté en el path
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from tracking.time_tracker import TimeTracker
+
+
+def _find_active_tracking() -> Path | None:
+    """Busca el archivo de tracking activo (sin completed_at)."""
+    tracking_dir = Path(".claude/tracking")
+    if not tracking_dir.exists():
+        return None
+    for json_file in sorted(tracking_dir.glob("*-tracking.json")):
+        try:
+            with open(json_file, 'r', encoding='utf-8') as f:
+                data = json.load(f)
+            if data.get("timeline", {}).get("completed_at") is None:
+                return json_file
+        except (json.JSONDecodeError, OSError):
+            continue
+    return None
+
+
+def _load_tracker(us_id: str | None) -> TimeTracker | None:
+    """Carga el tracker activo o el correspondiente al US_ID dado."""
+    if us_id:
+        path = Path(f".claude/tracking/{us_id}-tracking.json")
+        if path.exists():
+            return TimeTracker.from_json(path)
+        return None
+    tracking_file = _find_active_tracking()
+    if tracking_file:
+        return TimeTracker.from_json(tracking_file)
+    return None
+
+
+def cmd_start_phase(args: argparse.Namespace) -> None:
+    phase_num: int = args.phase
+    phase_name: str = args.name
+    us_id: str | None = args.us
+
+    tracker = _load_tracker(us_id)
+
+    if tracker is None:
+        if phase_num != 0:
+            print(
+                f"ERROR: No hay tracking activo. Usá --us <US_ID> para especificar la US.",
+                file=sys.stderr,
+            )
+            sys.exit(1)
+        if not us_id:
+            print(
+                "ERROR: Para iniciar tracking en fase 0 usá --us <US_ID>.",
+                file=sys.stderr,
+            )
+            sys.exit(1)
+        # Crear tracking nuevo para la fase 0
+        tracker = TimeTracker(
+            us_id=us_id,
+            us_title=us_id,
+            us_points=0,
+            producto="",
+        )
+        tracker.start_tracking()
+
+    tracker.start_phase(phase_num, phase_name)
+    print(f"▶  Fase {phase_num} iniciada: {phase_name}")
+
+
+def cmd_end_phase(args: argparse.Namespace) -> None:
+    tracker = _load_tracker(args.us)
+    if tracker is None:
+        print("ERROR: No hay tracking activo.", file=sys.stderr)
+        sys.exit(1)
+    tracker.end_phase(args.phase)
+    print(f"✓  Fase {args.phase} finalizada")
+
+
+def cmd_start_task(args: argparse.Namespace) -> None:
+    tracker = _load_tracker(args.us)
+    if tracker is None:
+        print("ERROR: No hay tracking activo.", file=sys.stderr)
+        sys.exit(1)
+    if tracker.current_phase is None:
+        print("ERROR: No hay fase activa.", file=sys.stderr)
+        sys.exit(1)
+    task_id = f"task_{len(tracker.current_phase.tasks) + 1:03d}"
+    tracker.start_task(task_id, args.name, "generic", 0)
+    print(f"▶  Tarea iniciada: {args.name}")
+
+
+def cmd_end_task(args: argparse.Namespace) -> None:
+    tracker = _load_tracker(args.us)
+    if tracker is None:
+        print("ERROR: No hay tracking activo.", file=sys.stderr)
+        sys.exit(1)
+    if tracker.current_task is None:
+        print("WARN: No hay tarea activa.", file=sys.stderr)
+        return
+    tracker.end_task(tracker.current_task.task_id)
+    print(f"✓  Tarea finalizada: {args.name}")
+
+
+def cmd_end_tracking(args: argparse.Namespace) -> None:
+    tracker = _load_tracker(args.us)
+    if tracker is None:
+        print("ERROR: No hay tracking activo.", file=sys.stderr)
+        sys.exit(1)
+    tracker.end_tracking()
+    print(f"✓  Tracking finalizado: {tracker.us_id}")
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="track.py",
+        description="CLI de tracking para /implement-us",
+    )
+    sub = parser.add_subparsers(dest="command", metavar="COMANDO")
+
+    sp = sub.add_parser("start-phase", help="Iniciar una fase")
+    sp.add_argument("phase", type=int, metavar="N", help="Número de fase (0-9)")
+    sp.add_argument("name", metavar="NOMBRE", help="Nombre de la fase")
+    sp.add_argument("--us", metavar="US_ID", help="ID de la Historia de Usuario")
+
+    ep = sub.add_parser("end-phase", help="Finalizar una fase")
+    ep.add_argument("phase", type=int, metavar="N")
+    ep.add_argument("--us", metavar="US_ID")
+
+    st = sub.add_parser("start-task", help="Iniciar una tarea")
+    st.add_argument("name", metavar="NOMBRE")
+    st.add_argument("--us", metavar="US_ID")
+
+    et = sub.add_parser("end-task", help="Finalizar una tarea")
+    et.add_argument("name", metavar="NOMBRE")
+    et.add_argument("--us", metavar="US_ID")
+
+    etk = sub.add_parser("end-tracking", help="Finalizar el tracking completo")
+    etk.add_argument("--us", metavar="US_ID")
+
+    return parser
+
+
+def main() -> None:
+    parser = _build_parser()
+    args = parser.parse_args()
+
+    commands = {
+        "start-phase": cmd_start_phase,
+        "end-phase": cmd_end_phase,
+        "start-task": cmd_start_task,
+        "end-task": cmd_end_task,
+        "end-tracking": cmd_end_tracking,
+    }
+
+    if args.command not in commands:
+        parser.print_help()
+        sys.exit(1)
+
+    commands[args.command](args)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Resuelve

Closes #35
Closes #36

## Cambios

### Issue #35 — Missing track.py CLI entry point

- **`tracking/track.py`** (nuevo): punto de entrada CLI que expone los comandos `start-phase`, `end-phase`, `start-task`, `end-task` y `end-tracking`. Soporta `--us <US_ID>` opcional en todos los comandos; requerido en `start-phase 0` para inicializar el tracking.
- **`tracking/time_tracker.py`**: agrega classmethod `TimeTracker.from_json(path)` que restaura el estado completo (fases, tareas, pausas, timestamps) desde el JSON persistido en disco.
- **`skills/implement-us/phases/phase-0-validation.md`**: el comando de tracking ahora incluye `--us {US_ID}` para que el CLI pueda crear el archivo de tracking al iniciar la fase 0.

### Issue #36 — Fase 7 no persiste reporte quality gates

- **`skills/implement-us/phases/phase-7-quality-gates.md`**: agrega sección `🔴 Acción Requerida — Generar reporte de quality gates` antes del checklist de salida, con el formato JSON completo y los comandos necesarios para crear `quality/reports/{US_ID}-quality.json`.

## Tests

- 6 tests nuevos para `TimeTracker.from_json()` en `tests/test_tracking.py`
- **44 tests, todos pasan**

🤖 Generated with [Claude Code](https://claude.com/claude-code)