### PR TITLE
feat(tracking): load(), tracker_cli.py y fix glob US-* — v1.4 PR B

### DIFF
--- a/tests/test_tracker_cli.py
+++ b/tests/test_tracker_cli.py
@@ -1,0 +1,271 @@
+"""
+Tests del módulo tracking/tracker_cli.py
+
+Cubre: _find_active_us_id, cmd_init, cmd_start_phase, cmd_end_phase,
+       cmd_start_task, cmd_end_task, cmd_status, cmd_end, TimeTracker.load
+"""
+import json
+import sys
+import pytest
+from pathlib import Path
+from unittest.mock import patch
+
+# Asegurar que tracking/ es importable
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from tracking.time_tracker import TimeTracker
+from tracking.tracker_cli import (
+    _find_active_us_id,
+    cmd_init,
+    cmd_start_phase,
+    cmd_end_phase,
+    cmd_start_task,
+    cmd_end_task,
+    cmd_status,
+    cmd_end,
+    build_parser,
+)
+
+
+# =============================================================================
+# Fixtures
+# =============================================================================
+
+@pytest.fixture(autouse=True)
+def chdir_tmp(tmp_path, monkeypatch):
+    """Todos los tests corren con cwd = tmp_path para aislar .claude/tracking/."""
+    monkeypatch.chdir(tmp_path)
+
+
+@pytest.fixture
+def active_tracker(tmp_path):
+    """TimeTracker iniciado, activo (completed_at=None)."""
+    t = TimeTracker("US-1.0.0", "Historia de prueba", 3, "test_prod")
+    t.start_tracking()
+    return t
+
+
+@pytest.fixture
+def parser():
+    return build_parser()
+
+
+# =============================================================================
+# Tests: TimeTracker.load
+# =============================================================================
+
+class TestTimeTrackerLoad:
+
+    def test_load_existing(self, active_tracker):
+        loaded = TimeTracker.load("US-1.0.0")
+        assert loaded.us_id == "US-1.0.0"
+        assert loaded.us_title == "Historia de prueba"
+
+    def test_load_restores_started_at(self, active_tracker):
+        loaded = TimeTracker.load("US-1.0.0")
+        assert loaded.started_at is not None
+
+    def test_load_missing_raises(self):
+        with pytest.raises(FileNotFoundError, match="US-INEXISTENTE"):
+            TimeTracker.load("US-INEXISTENTE")
+
+    def test_load_non_us_prefix(self):
+        t = TimeTracker("INC-2.0", "Incremento técnico", 2, "prod")
+        t.start_tracking()
+        loaded = TimeTracker.load("INC-2.0")
+        assert loaded.us_id == "INC-2.0"
+
+
+# =============================================================================
+# Tests: _find_active_us_id
+# =============================================================================
+
+class TestFindActiveUsId:
+
+    def test_finds_active_tracker(self, active_tracker):
+        assert _find_active_us_id() == "US-1.0.0"
+
+    def test_finds_non_us_prefix(self):
+        t = TimeTracker("INC-2.0", "Incremento", 2, "prod")
+        t.start_tracking()
+        assert _find_active_us_id() == "INC-2.0"
+
+    def test_no_active_raises(self):
+        with pytest.raises(RuntimeError, match="No hay trackers activos"):
+            _find_active_us_id()
+
+    def test_multiple_active_raises(self, active_tracker):
+        t2 = TimeTracker("US-2.0.0", "Segunda US", 2, "prod")
+        t2.start_tracking()
+        with pytest.raises(RuntimeError, match="Múltiples trackers activos"):
+            _find_active_us_id()
+
+    def test_completed_tracker_ignored(self, active_tracker):
+        active_tracker.end_tracking()
+        # Sin trackers activos ahora
+        with pytest.raises(RuntimeError, match="No hay trackers activos"):
+            _find_active_us_id()
+
+    def test_multiple_active_lists_both_ids(self, active_tracker):
+        t2 = TimeTracker("TEC-1.0", "Técnico", 1, "prod")
+        t2.start_tracking()
+        with pytest.raises(RuntimeError) as exc:
+            _find_active_us_id()
+        msg = str(exc.value)
+        assert "US-1.0.0" in msg
+        assert "TEC-1.0" in msg
+
+
+# =============================================================================
+# Tests: cmd_init
+# =============================================================================
+
+class TestCmdInit:
+
+    def test_creates_tracking_file(self, parser, capsys):
+        args = parser.parse_args(["init", "US-3.0.0", "Mi historia", "5", "mi_prod"])
+        cmd_init(args)
+        assert Path(".claude/tracking/US-3.0.0-tracking.json").exists()
+
+    def test_tracking_file_is_valid_json(self, parser):
+        args = parser.parse_args(["init", "US-3.0.0", "Mi historia", "5", "mi_prod"])
+        cmd_init(args)
+        data = json.loads(Path(".claude/tracking/US-3.0.0-tracking.json").read_text())
+        assert data["metadata"]["us_id"] == "US-3.0.0"
+
+    def test_prints_confirmation(self, parser, capsys):
+        args = parser.parse_args(["init", "US-3.0.0", "Mi historia", "5", "mi_prod"])
+        cmd_init(args)
+        out = capsys.readouterr().out
+        assert "US-3.0.0" in out
+
+
+# =============================================================================
+# Tests: cmd_start_phase / cmd_end_phase
+# =============================================================================
+
+class TestCmdPhase:
+
+    def test_start_phase_adds_phase(self, active_tracker, parser):
+        args = parser.parse_args(["start-phase", "0", "Validación de Contexto"])
+        cmd_start_phase(args)
+        loaded = TimeTracker.load("US-1.0.0")
+        assert len(loaded.phases) == 1
+        assert loaded.phases[0].phase_name == "Validación de Contexto"
+
+    def test_end_phase_completes_phase(self, active_tracker, parser):
+        args_sp = parser.parse_args(["start-phase", "0", "Validación de Contexto"])
+        cmd_start_phase(args_sp)
+        args_ep = parser.parse_args(["end-phase", "0"])
+        cmd_end_phase(args_ep)
+        loaded = TimeTracker.load("US-1.0.0")
+        assert loaded.phases[0].status == "completed"
+
+    def test_start_phase_explicit_us_id(self, active_tracker, parser):
+        args = parser.parse_args(["start-phase", "1", "BDD", "--us-id", "US-1.0.0"])
+        cmd_start_phase(args)
+        loaded = TimeTracker.load("US-1.0.0")
+        assert loaded.phases[0].phase_number == 1
+
+    def test_end_phase_sets_elapsed(self, active_tracker, parser):
+        cmd_start_phase(parser.parse_args(["start-phase", "0", "Validación"]))
+        cmd_end_phase(parser.parse_args(["end-phase", "0"]))
+        loaded = TimeTracker.load("US-1.0.0")
+        assert loaded.phases[0].elapsed_seconds >= 0
+
+
+# =============================================================================
+# Tests: cmd_start_task / cmd_end_task
+# =============================================================================
+
+class TestCmdTask:
+
+    def test_start_task_adds_task(self, active_tracker, parser):
+        cmd_start_phase(parser.parse_args(["start-phase", "3", "Implementación"]))
+        cmd_start_task(parser.parse_args(["start-task", "t001", "Crear aggregate", "dominio", "20"]))
+        loaded = TimeTracker.load("US-1.0.0")
+        assert len(loaded.phases[0].tasks) == 1
+        assert loaded.phases[0].tasks[0].task_id == "t001"
+
+    def test_end_task_completes_task(self, active_tracker, parser):
+        cmd_start_phase(parser.parse_args(["start-phase", "3", "Implementación"]))
+        cmd_start_task(parser.parse_args(["start-task", "t001", "Crear aggregate", "dominio", "20"]))
+        cmd_end_task(parser.parse_args(["end-task", "t001", "src/domain/aggregate.py"]))
+        loaded = TimeTracker.load("US-1.0.0")
+        assert loaded.phases[0].tasks[0].status == "completed"
+        assert loaded.phases[0].tasks[0].file_created == "src/domain/aggregate.py"
+
+    def test_end_task_without_file(self, active_tracker, parser):
+        cmd_start_phase(parser.parse_args(["start-phase", "3", "Implementación"]))
+        cmd_start_task(parser.parse_args(["start-task", "t001", "Tarea", "test", "5"]))
+        cmd_end_task(parser.parse_args(["end-task", "t001"]))
+        loaded = TimeTracker.load("US-1.0.0")
+        assert loaded.phases[0].tasks[0].file_created is None
+
+
+# =============================================================================
+# Tests: cmd_status
+# =============================================================================
+
+class TestCmdStatus:
+
+    def test_status_shows_us_id(self, active_tracker, parser, capsys):
+        cmd_status(parser.parse_args(["status"]))
+        out = capsys.readouterr().out
+        assert "US-1.0.0" in out
+
+    def test_status_shows_elapsed(self, active_tracker, parser, capsys):
+        cmd_status(parser.parse_args(["status"]))
+        out = capsys.readouterr().out
+        assert "min" in out
+
+    def test_status_shows_current_phase(self, active_tracker, parser, capsys):
+        cmd_start_phase(parser.parse_args(["start-phase", "0", "Validación"]))
+        cmd_status(parser.parse_args(["status"]))
+        out = capsys.readouterr().out
+        assert "Validación" in out
+
+
+# =============================================================================
+# Tests: cmd_end
+# =============================================================================
+
+class TestCmdEnd:
+
+    def test_end_marks_completed(self, active_tracker, parser):
+        cmd_end(parser.parse_args(["end"]))
+        data = json.loads(Path(".claude/tracking/US-1.0.0-tracking.json").read_text())
+        assert data["timeline"]["completed_at"] is not None
+
+    def test_end_explicit_us_id(self, active_tracker, parser):
+        cmd_end(parser.parse_args(["end", "US-1.0.0"]))
+        loaded = TimeTracker.load("US-1.0.0")
+        assert loaded.completed_at is not None
+
+    def test_end_prints_summary(self, active_tracker, parser, capsys):
+        cmd_end(parser.parse_args(["end"]))
+        out = capsys.readouterr().out
+        assert "US-1.0.0" in out
+        assert "finalizado" in out.lower()
+
+
+# =============================================================================
+# Tests: ciclo completo init → phase → task → end
+# =============================================================================
+
+class TestFullCycle:
+
+    def test_full_cycle(self, parser, capsys):
+        """Ciclo completo: init → start-phase → start-task → end-task → end-phase → end."""
+        cmd_init(parser.parse_args(["init", "US-9.9.9", "Ciclo completo", "5", "prod"]))
+        cmd_start_phase(parser.parse_args(["start-phase", "0", "Validación", "--us-id", "US-9.9.9"]))
+        cmd_start_task(parser.parse_args(["start-task", "t001", "Tarea A", "dominio", "10", "--us-id", "US-9.9.9"]))
+        cmd_end_task(parser.parse_args(["end-task", "t001", "--us-id", "US-9.9.9"]))
+        cmd_end_phase(parser.parse_args(["end-phase", "0", "--us-id", "US-9.9.9"]))
+        cmd_end(parser.parse_args(["end", "US-9.9.9"]))
+
+        loaded = TimeTracker.load("US-9.9.9")
+        assert loaded.completed_at is not None
+        assert len(loaded.phases) == 1
+        assert loaded.phases[0].status == "completed"
+        assert loaded.phases[0].tasks[0].status == "completed"

--- a/tracking/time_tracker.py
+++ b/tracking/time_tracker.py
@@ -398,6 +398,27 @@ class TimeTracker:
         )
 
     @classmethod
+    def load(cls, us_id: str) -> 'TimeTracker':
+        """Carga un TimeTracker desde su us_id, buscando en .claude/tracking/.
+
+        Args:
+            us_id: ID de la Historia de Usuario (ej: "US-001", "INC-2.0")
+
+        Returns:
+            Instancia de TimeTracker con estado completo restaurado
+
+        Raises:
+            FileNotFoundError: Si no existe el archivo de tracking para us_id
+        """
+        path = Path(f".claude/tracking/{us_id}-tracking.json")
+        if not path.exists():
+            raise FileNotFoundError(
+                f"No existe tracking para '{us_id}': {path}\n"
+                f"Inicializar con: tracker_cli.py init {us_id} ..."
+            )
+        return cls.from_json(path)
+
+    @classmethod
     def from_json(cls, file_path: Path) -> 'TimeTracker':
         """Carga un TimeTracker desde un archivo JSON existente.
 

--- a/tracking/tracker_cli.py
+++ b/tracking/tracker_cli.py
@@ -1,0 +1,233 @@
+#!/usr/bin/env python3
+"""
+tracker_cli.py — CLI wrapper para TimeTracker.
+
+Permite usar TimeTracker desde Bash entre fases del skill /implement-us.
+Carga el estado desde JSON en cada llamada y lo persiste al finalizar.
+
+Uso:
+    python .claude/tracking/tracker_cli.py init US-1.0.0 "Título" 3 producto
+    python .claude/tracking/tracker_cli.py start-phase 0 "Validación de Contexto"
+    python .claude/tracking/tracker_cli.py end-phase 0
+    python .claude/tracking/tracker_cli.py start-task task_001 "Nombre" dominio 20
+    python .claude/tracking/tracker_cli.py end-task task_001 src/modulo.py
+    python .claude/tracking/tracker_cli.py status
+    python .claude/tracking/tracker_cli.py end [us_id]
+"""
+import sys
+import json
+import argparse
+from glob import glob
+from pathlib import Path
+
+# Hacer importable el módulo tracking desde el directorio del proyecto
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from tracking.time_tracker import TimeTracker
+
+
+# =============================================================================
+# Lookup del tracker activo
+# =============================================================================
+
+def _find_active_us_id() -> str:
+    """Busca el us_id del tracker activo (completed_at == null).
+
+    Returns:
+        us_id del tracker activo
+
+    Raises:
+        RuntimeError: Si hay 0 o más de 1 tracker activo
+    """
+    files = glob(".claude/tracking/*-tracking.json")
+    activos = []
+    for f in files:
+        try:
+            data = json.loads(Path(f).read_text())
+            if data["timeline"]["completed_at"] is None:
+                activos.append(data["metadata"]["us_id"])
+        except (json.JSONDecodeError, KeyError):
+            continue
+
+    if len(activos) == 0:
+        raise RuntimeError(
+            "No hay trackers activos.\n"
+            "Inicializar con: tracker_cli.py init <us_id> <title> <points> <product>"
+        )
+    if len(activos) > 1:
+        lista = ", ".join(activos)
+        raise RuntimeError(
+            f"Múltiples trackers activos: {lista}\n"
+            "Cerrar los huérfanos antes de continuar:\n"
+            "  tracker_cli.py end <us_id>"
+        )
+    return activos[0]
+
+
+# =============================================================================
+# Subcomandos
+# =============================================================================
+
+def cmd_init(args: argparse.Namespace) -> None:
+    """Inicializa un nuevo tracker para una US."""
+    tracker = TimeTracker(
+        us_id=args.us_id,
+        us_title=args.title,
+        us_points=args.points,
+        producto=args.product,
+    )
+    tracker.start_tracking()
+    print(f"✅ Tracker iniciado: {args.us_id} — {args.title}")
+    print(f"   Archivo: .claude/tracking/{args.us_id}-tracking.json")
+
+
+def cmd_start_phase(args: argparse.Namespace) -> None:
+    """Inicia una fase en el tracker activo."""
+    us_id = args.us_id or _find_active_us_id()
+    tracker = TimeTracker.load(us_id)
+    tracker.start_phase(args.phase_number, args.phase_name)
+    print(f"▶️  Fase {args.phase_number} iniciada: {args.phase_name} [{us_id}]")
+
+
+def cmd_end_phase(args: argparse.Namespace) -> None:
+    """Cierra una fase en el tracker activo."""
+    us_id = args.us_id or _find_active_us_id()
+    tracker = TimeTracker.load(us_id)
+    tracker.end_phase(args.phase_number)
+    phase = tracker._get_phase(args.phase_number)
+    elapsed = f"{phase.elapsed_seconds}s" if phase else "?"
+    print(f"✅ Fase {args.phase_number} completada [{us_id}] — {elapsed}")
+
+
+def cmd_start_task(args: argparse.Namespace) -> None:
+    """Inicia una tarea dentro de la fase activa."""
+    us_id = args.us_id or _find_active_us_id()
+    tracker = TimeTracker.load(us_id)
+    tracker.start_task(args.task_id, args.task_name, args.task_type, args.estimated_minutes)
+    print(f"▶️  Tarea iniciada: {args.task_id} — {args.task_name} [{us_id}]")
+
+
+def cmd_end_task(args: argparse.Namespace) -> None:
+    """Cierra una tarea en la fase activa."""
+    us_id = args.us_id or _find_active_us_id()
+    tracker = TimeTracker.load(us_id)
+    tracker.end_task(args.task_id, args.file_created)
+    print(f"✅ Tarea completada: {args.task_id} [{us_id}]")
+    if args.file_created:
+        print(f"   Archivo: {args.file_created}")
+
+
+def cmd_status(args: argparse.Namespace) -> None:
+    """Muestra el estado actual del tracker activo."""
+    us_id = args.us_id or _find_active_us_id()
+    tracker = TimeTracker.load(us_id)
+    status = tracker.get_status()
+
+    print(f"\n📊 Tracking: {us_id}")
+    print(f"   Estado:   {status['status']}")
+    if status.get("current_phase"):
+        print(f"   Fase:     {status['current_phase']}")
+    if status.get("current_task"):
+        print(f"   Tarea:    {status['current_task']}")
+
+    elapsed_min = status.get("elapsed_seconds", 0) // 60
+    effective_min = status.get("effective_seconds", 0) // 60
+    print(f"   Elapsed:  {elapsed_min} min  (efectivo: {effective_min} min)")
+
+    total = status.get("total_tasks", 0)
+    done = status.get("completed_tasks", 0)
+    if total > 0:
+        print(f"   Tareas:   {done}/{total} completadas")
+    print()
+
+
+def cmd_end(args: argparse.Namespace) -> None:
+    """Cierra el tracker completo de una US."""
+    us_id = args.us_id or _find_active_us_id()
+    tracker = TimeTracker.load(us_id)
+    tracker.end_tracking()
+
+    elapsed = 0
+    if tracker.started_at and tracker.completed_at:
+        elapsed = int((tracker.completed_at - tracker.started_at).total_seconds()) // 60
+
+    print(f"🏁 Tracking finalizado: {us_id}")
+    print(f"   Fases completadas: {len(tracker.phases)}")
+    print(f"   Tiempo total: {elapsed} min")
+    print(f"   Archivo: {tracker.storage_path}")
+
+
+# =============================================================================
+# Parser principal
+# =============================================================================
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="tracker_cli.py",
+        description="CLI wrapper para TimeTracker — usar desde phase files del skill /implement-us",
+    )
+    sub = parser.add_subparsers(dest="command", metavar="SUBCOMANDO")
+    sub.required = True
+
+    # init
+    p_init = sub.add_parser("init", help="Inicializar tracker para una nueva US")
+    p_init.add_argument("us_id", help="ID de la US (ej: US-1.0.0, INC-2.0)")
+    p_init.add_argument("title", help="Título de la US")
+    p_init.add_argument("points", type=int, help="Story points")
+    p_init.add_argument("product", help="Nombre del producto")
+    p_init.set_defaults(func=cmd_init)
+
+    # start-phase
+    p_sp = sub.add_parser("start-phase", help="Iniciar una fase")
+    p_sp.add_argument("phase_number", type=int, help="Número de fase (0-9)")
+    p_sp.add_argument("phase_name", help="Nombre descriptivo de la fase")
+    p_sp.add_argument("--us-id", dest="us_id", default=None, help="us_id explícito (opcional)")
+    p_sp.set_defaults(func=cmd_start_phase)
+
+    # end-phase
+    p_ep = sub.add_parser("end-phase", help="Cerrar una fase")
+    p_ep.add_argument("phase_number", type=int, help="Número de fase (0-9)")
+    p_ep.add_argument("--us-id", dest="us_id", default=None, help="us_id explícito (opcional)")
+    p_ep.set_defaults(func=cmd_end_phase)
+
+    # start-task
+    p_st = sub.add_parser("start-task", help="Iniciar una tarea")
+    p_st.add_argument("task_id", help="ID de la tarea (ej: task_001)")
+    p_st.add_argument("task_name", help="Nombre de la tarea")
+    p_st.add_argument("task_type", help="Tipo (dominio, infra, test, etc.)")
+    p_st.add_argument("estimated_minutes", type=float, help="Estimación en minutos")
+    p_st.add_argument("--us-id", dest="us_id", default=None, help="us_id explícito (opcional)")
+    p_st.set_defaults(func=cmd_start_task)
+
+    # end-task
+    p_et = sub.add_parser("end-task", help="Cerrar una tarea")
+    p_et.add_argument("task_id", help="ID de la tarea")
+    p_et.add_argument("file_created", nargs="?", default=None, help="Archivo principal creado (opcional)")
+    p_et.add_argument("--us-id", dest="us_id", default=None, help="us_id explícito (opcional)")
+    p_et.set_defaults(func=cmd_end_task)
+
+    # status
+    p_status = sub.add_parser("status", help="Ver estado del tracker activo")
+    p_status.add_argument("--us-id", dest="us_id", default=None, help="us_id explícito (opcional)")
+    p_status.set_defaults(func=cmd_status)
+
+    # end
+    p_end = sub.add_parser("end", help="Finalizar el tracker completo")
+    p_end.add_argument("us_id", nargs="?", default=None, help="us_id (opcional, detecta el activo)")
+    p_end.set_defaults(func=cmd_end)
+
+    return parser
+
+
+def main() -> None:
+    parser = build_parser()
+    args = parser.parse_args()
+    try:
+        args.func(args)
+    except (FileNotFoundError, RuntimeError, ValueError) as e:
+        print(f"❌ {e}", file=sys.stderr)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Resumen

- `TimeTracker.load(us_id)` — carga estado completo desde JSON sin necesidad de sesión Python continua
- `tracker_cli.py` — CLI wrapper Bash con 7 subcomandos para usar desde phase files
- Fix glob `US-*` → `*-tracking.json` — soporta cualquier prefijo de US_ID (INC-*, TEC-*, etc.)
- Validación explícita cuando hay 0 o 2+ trackers activos (antes: fallo silencioso)

## Issues que cierra

Closes #42
Closes #45

## Cambios

- `tracking/time_tracker.py`: nuevo `classmethod load(us_id)` que delega en `from_json()`
- `tracking/tracker_cli.py`: nuevo archivo con subcomandos `init`, `start-phase`, `end-phase`, `start-task`, `end-task`, `status`, `end`
- `tests/test_tracker_cli.py`: 27 tests nuevos — ciclo completo, prefijos no-US, validaciones de error

## Uso desde phase files

```bash
# Inicio de US (Fase 0)
python .claude/tracking/tracker_cli.py init US-1.0.0 "Título" 3 producto
python .claude/tracking/tracker_cli.py start-phase 0 "Validación de Contexto"

# Cierre de fase
python .claude/tracking/tracker_cli.py end-phase 0

# Cierre de US (Fase 9)
python .claude/tracking/tracker_cli.py end
```

## Test plan

- [ ] 142/142 tests passing (verificado localmente)
- [ ] Funciona con prefijos `INC-*`, `TEC-*` además de `US-*`
- [ ] Error explícito con 0 trackers activos y con 2+ activos simultáneos

🤖 Generated with [Claude Code](https://claude.com/claude-code)