### PR TITLE
feat(pipeline): migrar fases a tracker_cli.py y agregar gates ejecutables

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -17,7 +17,25 @@
       "Bash(cat:*)",
       "Bash(git rm docs/session-memory-improvements.md)",
       "Bash(done)",
-      "Bash(git push:*)"
+      "Bash(git push:*)",
+      "Bash(gh release:*)",
+      "Bash(gh wiki:*)",
+      "Bash(git checkout:*)",
+      "Bash(read f:*)",
+      "Bash(gh pr:*)",
+      "Bash(python -m pytest tests/test_tracking.py -v 2>&1 | tail -40)",
+      "Bash(rm:*)",
+      "Bash(gh issue:*)",
+      "Bash(git pull:*)",
+      "Bash(git tag:*)",
+      "Bash(python3 -m json.tool)",
+      "Bash(python3 -c \"import json,sys; d=json.load\\(sys.stdin\\); print\\(json.dumps\\({k:v for k,v in d.items\\(\\) if 'profile' in k.lower\\(\\) or 'active' in k.lower\\(\\) or 'customiz' in k.lower\\(\\)}, indent=2\\)\\)\")",
+      "Bash(python3 -c ':*)",
+      "Bash(python *)",
+      "Bash(git rm *)",
+      "Bash(python3 -c \"import json,sys; d=json.load\\(sys.stdin\\); print\\('mergeable:', d['mergeable']\\); print\\('reviews:', d['reviews']\\); print\\('checks:', [\\(c['name'], c['conclusion']\\) for c in d.get\\('statusCheckRollup',[]\\)]\\)\")",
+      "Bash(sed -i '' 's|python .claude/tracking/track\\\\.py start-phase 3|python .claude/tracking/tracker_cli.py start-phase 3|g' 's|python .claude/tracking/track\\\\.py end-phase 3|python .claude/tracking/tracker_cli.py end-phase 3|g' /Users/victor/PycharmProjects/claude-dev-kitc/skills/implement-us/phases/phase-3-implementation.md)",
+      "Bash(sed -i '' 's|python .claude/tracking/track\\\\.py|python .claude/tracking/tracker_cli.py|g' /Users/victor/PycharmProjects/claude-dev-kitc/skills/implement-us/phases/phase-3-implementation.md)"
     ]
   }
 }

--- a/skills/implement-us/phases/phase-0-validation.md
+++ b/skills/implement-us/phases/phase-0-validation.md
@@ -11,7 +11,8 @@
 Ejecutá este comando antes de cualquier otra acción en esta fase:
 
 ```bash
-python .claude/tracking/track.py start-phase 0 "Validación de Contexto" --us {US_ID}
+python .claude/tracking/tracker_cli.py init {US_ID} "{US_TITLE}" {STORY_POINTS} {PRODUCT}
+python .claude/tracking/tracker_cli.py start-phase 0 "Validación de Contexto"
 ```
 
 ---
@@ -237,7 +238,7 @@ Antes de avanzar a Fase 1, confirmá que:
 ## Paso 10 🔴 — Cerrar tracking
 
 ```bash
-python .claude/tracking/track.py end-phase 0
+python .claude/tracking/tracker_cli.py end-phase 0
 ```
 
 ---

--- a/skills/implement-us/phases/phase-1-bdd.md
+++ b/skills/implement-us/phases/phase-1-bdd.md
@@ -23,7 +23,7 @@ Si no existe, **no avances** — completá Fase 0 primero.
 Ejecutá antes de cualquier otra acción en esta fase:
 
 ```bash
-python .claude/tracking/track.py start-phase 1 "Generación de Escenarios BDD"
+python .claude/tracking/tracker_cli.py start-phase 1 "Generación de Escenarios BDD"
 ```
 
 ---
@@ -156,7 +156,7 @@ Antes de avanzar a Fase 2, confirmá que:
 ## Paso 7 🔴 — Cerrar tracking
 
 ```bash
-python .claude/tracking/track.py end-phase 1
+python .claude/tracking/tracker_cli.py end-phase 1
 ```
 
 ---

--- a/skills/implement-us/phases/phase-2-planning.md
+++ b/skills/implement-us/phases/phase-2-planning.md
@@ -23,7 +23,7 @@ Si no existe, **no avances** — ejecutá Fase 0 primero.
 Ejecutá antes de cualquier otra acción en esta fase:
 
 ```bash
-python .claude/tracking/track.py start-phase 2 "Generación del Plan de Implementación"
+python .claude/tracking/tracker_cli.py start-phase 2 "Generación del Plan de Implementación"
 ```
 
 ---
@@ -114,7 +114,7 @@ Antes de avanzar a Fase 3, confirmá que:
 ## Paso 8 🔴 — Cerrar tracking
 
 ```bash
-python .claude/tracking/track.py end-phase 2
+python .claude/tracking/tracker_cli.py end-phase 2
 ```
 
 ---

--- a/skills/implement-us/phases/phase-3-implementation.md
+++ b/skills/implement-us/phases/phase-3-implementation.md
@@ -10,7 +10,7 @@
 Ejecutá como primera acción, antes de cualquier otra:
 
 ```bash
-python .claude/tracking/track.py start-phase 3 "Implementación Guiada por Tareas"
+python .claude/tracking/tracker_cli.py start-phase 3 "Implementación Guiada por Tareas"
 ```
 
 ---
@@ -87,7 +87,7 @@ Identificar la primera tarea no completada del plan generado en Fase 2.
 Ejecutá antes de comenzar la implementación de cada tarea:
 
 ```bash
-python .claude/tracking/track.py start-task "{TASK_NAME}"
+python .claude/tracking/tracker_cli.py start-task "{TASK_ID}" "{TASK_NAME}" "{TASK_TYPE}" {ESTIMATED_MINUTES}
 ```
 
 ---
@@ -716,7 +716,7 @@ python -m py_compile {COMPONENT_PATH}/{filename}.py
 Ejecutá inmediatamente después de completar la tarea:
 
 ```bash
-python .claude/tracking/track.py end-task "{TASK_NAME}"
+python .claude/tracking/tracker_cli.py end-task "{TASK_ID}" "{FILE_CREATED}"
 ```
 
 ---
@@ -886,7 +886,7 @@ Antes de avanzar a Fase 4, confirmá que:
 ## 🔴 Acción Requerida — Cerrar tracking
 
 ```bash
-python .claude/tracking/track.py end-phase 3
+python .claude/tracking/tracker_cli.py end-phase 3
 ```
 
 ---

--- a/skills/implement-us/phases/phase-4-unit-tests.md
+++ b/skills/implement-us/phases/phase-4-unit-tests.md
@@ -22,7 +22,7 @@ Si no existe, **no avances** — completá la fase correspondiente primero.
 Ejecutá como primera acción, antes de cualquier otra:
 
 ```bash
-python .claude/tracking/track.py start-phase 4 "Tests Unitarios"
+python .claude/tracking/tracker_cli.py start-phase 4 "Tests Unitarios"
 ```
 
 ---
@@ -1022,7 +1022,7 @@ Antes de avanzar a Fase 5, confirmá que:
 ## 🔴 Acción Requerida — Cerrar tracking
 
 ```bash
-python .claude/tracking/track.py end-phase 4
+python .claude/tracking/tracker_cli.py end-phase 4
 ```
 
 ---

--- a/skills/implement-us/phases/phase-5-integration-tests.md
+++ b/skills/implement-us/phases/phase-5-integration-tests.md
@@ -26,7 +26,7 @@ Si algún test falla, **no avances** — completá Fase 4 primero.
 Ejecutá como primera acción, antes de cualquier otra:
 
 ```bash
-python .claude/tracking/track.py start-phase 5 "Tests de Integración"
+python .claude/tracking/tracker_cli.py start-phase 5 "Tests de Integración"
 ```
 
 ---
@@ -553,7 +553,7 @@ Antes de avanzar a Fase 6, confirmá que:
 ## 🔴 Acción Requerida — Cerrar tracking
 
 ```bash
-python .claude/tracking/track.py end-phase 5
+python .claude/tracking/tracker_cli.py end-phase 5
 ```
 
 ---

--- a/skills/implement-us/phases/phase-6-bdd-validation.md
+++ b/skills/implement-us/phases/phase-6-bdd-validation.md
@@ -22,7 +22,7 @@ Si no existe, **no avances** — completá la fase correspondiente primero.
 Ejecutá como primera acción, antes de cualquier otra:
 
 ```bash
-python .claude/tracking/track.py start-phase 6 "Validación BDD"
+python .claude/tracking/tracker_cli.py start-phase 6 "Validación BDD"
 ```
 
 ---
@@ -453,7 +453,7 @@ Antes de avanzar a Fase 7, confirmá que:
 ## 🔴 Acción Requerida — Cerrar tracking
 
 ```bash
-python .claude/tracking/track.py end-phase 6
+python .claude/tracking/tracker_cli.py end-phase 6
 ```
 
 ---

--- a/skills/implement-us/phases/phase-7-quality-gates.md
+++ b/skills/implement-us/phases/phase-7-quality-gates.md
@@ -10,7 +10,7 @@
 Ejecutá como primera acción, antes de cualquier otra:
 
 ```bash
-python .claude/tracking/track.py start-phase 7 "Quality Gates"
+python .claude/tracking/tracker_cli.py start-phase 7 "Quality Gates"
 ```
 
 ---
@@ -546,10 +546,22 @@ Antes de avanzar a Fase 8, confirmá que:
 - [ ] Coverage ≥ umbral del perfil activo
 - [ ] Tracking de Fase 7 cerrado
 
+## 🔴 Acción Requerida — Verificar reporte antes de cerrar
+
+Confirmá que el reporte de quality gates existe en disco antes de avanzar a Fase 8:
+
+```bash
+ls quality/reports/{US_ID}-quality.json
+```
+
+Si no existe, generalo con los valores reales obtenidos en los pasos anteriores (ver sección "Generar Reporte Consolidado").
+
+---
+
 ## 🔴 Acción Requerida — Cerrar tracking
 
 ```bash
-python .claude/tracking/track.py end-phase 7
+python .claude/tracking/tracker_cli.py end-phase 7
 ```
 
 ---

--- a/skills/implement-us/phases/phase-8-documentation.md
+++ b/skills/implement-us/phases/phase-8-documentation.md
@@ -22,7 +22,7 @@ Si no existe, **no avances** — completá la fase correspondiente primero.
 Ejecutá como primera acción, antes de cualquier otra:
 
 ```bash
-python .claude/tracking/track.py start-phase 8 "Actualización de Documentación"
+python .claude/tracking/tracker_cli.py start-phase 8 "Actualización de Documentación"
 ```
 
 ---
@@ -437,7 +437,7 @@ Antes de avanzar a Fase 9, confirmá que:
 ## 🔴 Acción Requerida — Cerrar tracking
 
 ```bash
-python .claude/tracking/track.py end-phase 8
+python .claude/tracking/tracker_cli.py end-phase 8
 ```
 
 ---

--- a/skills/implement-us/phases/phase-9-final-report.md
+++ b/skills/implement-us/phases/phase-9-final-report.md
@@ -23,7 +23,7 @@ Si alguno no existe, **no avances** — completá la fase correspondiente primer
 Ejecutá como primera acción, antes de cualquier otra:
 
 ```bash
-python .claude/tracking/track.py start-phase 9 "Reporte Final"
+python .claude/tracking/tracker_cli.py start-phase 9 "Reporte Final"
 ```
 
 ---
@@ -497,18 +497,30 @@ Antes de cerrar el tracking, confirmá que:
 
 ---
 
+## 🔴 Acción Requerida — Verificar reporte antes de cerrar
+
+Confirmá que el reporte final existe en disco antes de cerrar el tracking:
+
+```bash
+ls docs/reports/{US_ID}-report.md
+```
+
+Si no existe, generalo usando el template de la sección anterior antes de continuar.
+
+---
+
 ## 🔴 Acción Requerida — Cerrar tracking
 
 ```bash
 # Cerrar fase 9
-python .claude/tracking/track.py end-phase 9
+python .claude/tracking/tracker_cli.py end-phase 9
 
 # Cerrar tracking completo de la US
-python .claude/tracking/track.py end-tracking
+python .claude/tracking/tracker_cli.py end
 ```
 
-> **¿Qué hace `end-tracking`?** Es el único punto del skill donde se invoca este subcomando.
-> A diferencia de `end-phase` (que cierra solo la fase actual), `end-tracking` cierra el
+> **¿Qué hace `end`?** Es el único punto del skill donde se invoca este subcomando.
+> A diferencia de `end-phase` (que cierra solo la fase actual), `end` cierra el
 > tracking completo de la US: calcula el tiempo total real acumulado en todas las fases,
 > guarda el histórico en `.claude/tracking/` y genera el reporte de tiempo final.
 > Debe ejecutarse **después** de `end-phase 9`, no en lugar de él.


### PR DESCRIPTION
## Summary

- **TICKET-099** (Closes #43): Migra comandos de tracking en todos los archivos de fase (0–9) de `track.py` a `tracker_cli.py`. Fase 0 agrega el comando `init` previo al `start-phase`. Fase 3 corrige el formato de `start-task`/`end-task` con argumentos explícitos. Fase 9 reemplaza `end-tracking` → `end`.
- **TICKET-097** (Closes #44): Agrega gate ejecutable en Fase 7: `ls quality/reports/{US_ID}-quality.json` antes de cerrar el tracking, bloqueando el avance a Fase 8 si el reporte no existe.
- **TICKET-098** (Closes #44): Agrega gate ejecutable en Fase 9: `ls docs/reports/{US_ID}-report.md` antes de cerrar el tracking, bloqueando el cierre si el reporte final no existe.

## Test plan

- [ ] Verificar que ningún archivo de fase referencia `track.py` o `end-tracking`
- [ ] Verificar que fase-0 incluye `tracker_cli.py init` antes de `start-phase`
- [ ] Verificar que fase-3 usa `start-task task_id task_name task_type minutes`
- [ ] Verificar que fase-7 tiene gate `ls quality/reports/{US_ID}-quality.json`
- [ ] Verificar que fase-9 tiene gate `ls docs/reports/{US_ID}-report.md` y usa `tracker_cli.py end`

🤖 Generated with [Claude Code](https://claude.com/claude-code)